### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/test/unit/tpls/00_LineBreaks/_in.php
+++ b/test/unit/tpls/00_LineBreaks/_in.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
+    "boolVal" => true,
     "textVal" => "text"
 ];

--- a/test/unit/tpls/02_basic_if/_in.php
+++ b/test/unit/tpls/02_basic_if/_in.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
-    "falseVal" => FALSE,
+    "boolVal" => true,
+    "falseVal" => false,
     "value1" => "Some Value",
     "floatVal" => 1.234,
     "emptyVal" => null

--- a/test/unit/tpls/03_nested_if/_in.php
+++ b/test/unit/tpls/03_nested_if/_in.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
-    "boolVal2" => TRUE,
+    "boolVal" => true,
+    "boolVal2" => true,
     "value1" => "Some Value",
 ];

--- a/test/unit/tpls/04_simple_for/_in.php
+++ b/test/unit/tpls/04_simple_for/_in.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
+    "boolVal" => true,
     "arrVal1" => [
         "a", "b", "c"
     ],

--- a/test/unit/tpls/05_nested_for/_in.php
+++ b/test/unit/tpls/05_nested_for/_in.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
+    "boolVal" => true,
     "arrVal1" => [
         "a", "b", "c"
     ],

--- a/test/unit/tpls/06_debug_vars/_in.php
+++ b/test/unit/tpls/06_debug_vars/_in.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    "boolVal" => TRUE,
+    "boolVal" => true,
     "arrVal1" => [
         "a", "b", "c"
     ],

--- a/test/unit/tpls/07_if_else/_in.php
+++ b/test/unit/tpls/07_if_else/_in.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "boolVal" => TRUE
+    "boolVal" => true
 ];

--- a/test/unit/tpls/08_if_elseif/_in.php
+++ b/test/unit/tpls/08_if_elseif/_in.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "boolVal" => TRUE
+    "boolVal" => true
 ];

--- a/test/unit/tpls/09_if_elseif_complex/_in.php
+++ b/test/unit/tpls/09_if_elseif_complex/_in.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    "t1" => TRUE,
-    "t2" => TRUE
+    "t1" => true,
+    "t2" => true
 ];

--- a/test/unit/tpls/10_logic/_in.php
+++ b/test/unit/tpls/10_logic/_in.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    "t1" => TRUE,
-    "t2" => TRUE
+    "t1" => true,
+    "t2" => true
 ];


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!