### PR TITLE
Fixed warning in PHP8.1

### DIFF
--- a/src/UndefinedVariableException.php
+++ b/src/UndefinedVariableException.php
@@ -17,7 +17,7 @@ class UndefinedVariableException extends TemplateParsingException
     protected $triggerVarName;
     public function __construct(
         $message = "",
-        $triggerVarName,
+        $triggerVarName = null,
         Throwable $previous = null
     ) {
         $this->triggerVarName = $triggerVarName;


### PR DESCRIPTION
E_DEPRECATED: Optional parameter $message declared before required parameter $triggerVarName is implicitly treated as a required parameter