### PR TITLE
Bugfix: throw exception on null value or cast it into string

### DIFF
--- a/src/TextTemplate.php
+++ b/src/TextTemplate.php
@@ -65,13 +65,24 @@ class TextTemplate {
      */
     private $sections = [];
 
-    public function __construct ($text="") {
+    /**
+     * @var bool
+     */
+    private $castNullIntoString;
+
+
+    /**
+     * @param string $text
+     * @param bool $castNullIntoString
+     */
+    public function __construct ($text="", $castNullIntoString=false) {
 
         $this->mTemplateText = $text;
         $this->mFilter = self::$__DEFAULT_FILTER;
         $this->mFunctions = self::$__DEFAULT_FUNCTION;
         $this->mOperators = self::$__DEFAULT_OPERATOR;
         $this->sections = self::$__DEFAULT_SECTIONS;
+        $this->castNullIntoString = $castNullIntoString;
     }
 
     public function setOpenCloseTagChars($open="{", $close="}")
@@ -393,6 +404,13 @@ class TextTemplate {
 
     private function _parseValueOfTags ($context, $item, $softFail) {
         $value = $this->_getItemValueWithFilters($context, $item, $softFail);
+        if ($value === null) {
+            if ( ! $this->castNullIntoString) {
+                $item = trim($item);
+                throw new TemplateParsingException("Value for item '{$item}' must not be null!");
+            }
+            $value = "";
+        }
 
         $chain = $this->_parseItemChain($item);
         if ( ! in_array("raw", $chain)) {


### PR DESCRIPTION
Due to new behaviour of PHP 8.1 it is no longer allowed to pass null values into string functions like `htmlspecialchars()`.  
So this causes errors while rendering TextTemplate with a message like: `htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated`.  
But this type of message is not really useful to find the root of the cause...

This PR changes the method `TextTemplate::_parseValueOfTags()`.  
Before a value is passed to the filters it will be checked and a TemplateParsingException is thrown or the value is just set to  an empty string otherwise.  
It depends on the new constructor's boolean parameter `$castNullIntoString` which action will be taken.  

I'm not sure about the default behaviour...  
I personally prefer throwing an exception 'cause there might be something wrong.  
Others may prefer the casting variant / overwriting null with an empty string.  
@dermatthes please take a look at the changes before merging.